### PR TITLE
Android O Support

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.1.0'
+        classpath 'com.android.tools.build:gradle:2.3.0'
         classpath 'com.github.dcendents:android-maven-plugin:1.2'
     }
 }

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -1,13 +1,13 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.0"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         applicationId "com.danialgoodwin.globaloverlay.demo"
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "1.0"
     }
@@ -23,11 +23,12 @@ repositories {
     maven {
         url "https://jitpack.io"
     }
+    maven { url "https://maven.google.com" }
 }
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.android.support:appcompat-v7:22.0.0'
+    compile 'com.android.support:appcompat-v7:26.0.0'
 
     compile project(':globaloverlay')
     // Use the following in your own project since it's not local.

--- a/demo/src/main/java/com/danialgoodwin/globaloverlay/demo/MainActivity.java
+++ b/demo/src/main/java/com/danialgoodwin/globaloverlay/demo/MainActivity.java
@@ -1,20 +1,18 @@
 package com.danialgoodwin.globaloverlay.demo;
 
 import android.content.Intent;
-import android.support.v7.app.ActionBarActivity;
 import android.os.Bundle;
-import android.view.Menu;
-import android.view.MenuItem;
+import android.support.v7.app.AppCompatActivity;
 import android.view.View;
 import android.widget.Button;
 
 
-public class MainActivity extends ActionBarActivity {
+public class MainActivity extends AppCompatActivity {
 
     private Button mStartOverlayButton;
 
     private void assignViews() {
-        mStartOverlayButton = (Button) findViewById(R.id.startOverlayButton);
+        mStartOverlayButton = findViewById(R.id.startOverlayButton);
     }
 
     @Override

--- a/globaloverlay/build.gradle
+++ b/globaloverlay/build.gradle
@@ -1,13 +1,12 @@
 apply plugin: 'com.android.library'
-apply plugin: 'android-maven'
 
 android {
-    compileSdkVersion 22
-    buildToolsVersion "22.0.0"
+    compileSdkVersion 26
+    buildToolsVersion '26.0.1'
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 22
+        targetSdkVersion 26
         versionCode 1
         versionName "0.9"
     }

--- a/globaloverlay/src/main/java/com/danialgoodwin/globaloverlay/GlobalOverlay.java
+++ b/globaloverlay/src/main/java/com/danialgoodwin/globaloverlay/GlobalOverlay.java
@@ -7,6 +7,7 @@ package com.danialgoodwin.globaloverlay;
 import android.annotation.SuppressLint;
 import android.content.Context;
 import android.graphics.PixelFormat;
+import android.os.Build;
 import android.util.Log;
 import android.view.Gravity;
 import android.view.LayoutInflater;
@@ -186,7 +187,7 @@ public class GlobalOverlay {
         WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
-                WindowManager.LayoutParams.TYPE_PHONE,
+                getTypeForWindow(),
 //                WindowManager.LayoutParams.FLAG_NOT_TOUCH_MODAL,
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE,
                 PixelFormat.TRANSLUCENT);
@@ -195,10 +196,11 @@ public class GlobalOverlay {
     }
 
     private static WindowManager.LayoutParams newWindowManagerLayoutParamsForRemoveView() {
+
         WindowManager.LayoutParams params = new WindowManager.LayoutParams(
                 WindowManager.LayoutParams.WRAP_CONTENT,
                 WindowManager.LayoutParams.WRAP_CONTENT,
-                WindowManager.LayoutParams.TYPE_PHONE,
+                getTypeForWindow(),
                 WindowManager.LayoutParams.FLAG_NOT_FOCUSABLE |
                         WindowManager.LayoutParams.FLAG_WATCH_OUTSIDE_TOUCH |
                         WindowManager.LayoutParams.FLAG_LAYOUT_NO_LIMITS,
@@ -208,12 +210,20 @@ public class GlobalOverlay {
         return params;
     }
 
+    private static int getTypeForWindow() {
+        int type = WindowManager.LayoutParams.TYPE_PHONE;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+            type = WindowManager.LayoutParams.TYPE_APPLICATION_OVERLAY;
+        }
+        return type;
+    }
+
     /** Interface definition for when an overlay view has been removed. */
-    public static interface OnRemoveOverlayListener {
+    public interface OnRemoveOverlayListener {
         /** This overlay has been removed.
          * @param v the removed view
          * @param isRemovedByUser true if user manually removed view, false if removed another way */
-        public void onRemoveOverlay(View v, boolean isRemovedByUser);
+        void onRemoveOverlay(View v, boolean isRemovedByUser);
     }
 
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Wed Apr 10 15:27:10 PDT 2013
+#Wed Aug 02 20:40:15 PDT 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.2.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip


### PR DESCRIPTION
- Adds support for Android O
- Updates gradle to version usable with current version of Android Studio.
- Updates compileSdk and support library Android O versions.
- Changes demo to extend AppCompatActivity since ActionBarActivity isn't used anymore.

This project is looking pretty dead, but I needed to use this anyway, and these changes can probably benefit another GitHub surfer like myself. Let me know if there's anything you're not a fan of; I don't mind changing it. 